### PR TITLE
setmag asserts that vector has direction

### DIFF
--- a/vector.lua
+++ b/vector.lua
@@ -84,6 +84,7 @@ end
 
 -- set the magnitude of a vector
 function vector:setmag(mag)
+  assert(self:getmag() ~= 0, "Cannot set magnitude when direction is ambiguous")
   self:norm()
   local v = self * mag
   self:replace(v)


### PR DESCRIPTION
Setting the magnitude when the vector has an undefined direction is invalid. This creates a warning so that the zero-case is not missed.